### PR TITLE
fix issue with lock file destination 

### DIFF
--- a/chan_dongle.c
+++ b/chan_dongle.c
@@ -116,7 +116,7 @@ static int lock_build(const char * devname, char * buf, unsigned length)
 		basename = devname;
 
 	/* NOTE: use system system wide lock directory */
-	return snprintf(buf, length, "/var/lock/LCK..%s", basename);
+	return snprintf(buf, length, "/var/lock/chan_dongle/LCK..%s", basename);
 }
 
 #/* return 0 on error */

--- a/etc/tmpfiles.d-chan_dongle.conf
+++ b/etc/tmpfiles.d-chan_dongle.conf
@@ -1,0 +1,5 @@
+#/usr/lib/tmpfiles.d/chan_dongle.conf
+
+#Type Path                         Mode UID      GID      Age Argument
+d     /run/lock/chan_dongle        0755 asterisk asterisk -   -
+r!    /var/lock/chan_dongle/LCK..*

--- a/tools/tty.c
+++ b/tools/tty.c
@@ -44,7 +44,7 @@ static int lock_build(const char * devname, char * buf, unsigned length)
 		basename = devname;
 
 	/* TODO: use asterisk build settings for /var/lock */
-	return snprintf(buf, length, "/var/lock/LCK..%s", basename);
+	return snprintf(buf, length, "/var/lock/chan_dongle/LCK..%s", basename);
 }
 
 #/* return 0 on error */


### PR DESCRIPTION
so that lock files are stored in sub-folder chan_dongle/ inside /var/lock so that proper permissions can be set for asterisk user using chan_dongle.conf in /usr/lib/tmpfiles.d/